### PR TITLE
Fix for shapes.txt header with test

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master, add-* ]
+    branches: [ master, add-*, fix-* ]
   pull_request:
     branches: [ master ]
 

--- a/include/just_gtfs/just_gtfs.h
+++ b/include/just_gtfs/just_gtfs.h
@@ -200,7 +200,7 @@ inline void write_routes_header(std::ofstream & out)
 inline void write_shapes_header(std::ofstream & out)
 {
   std::vector<std::string> fields = {"shape_id", "shape_pt_lat", "shape_pt_lon",
-                                     "shape_pt_sequence"};
+                                     "shape_pt_sequence", "shape_dist_traveled"};
   write_joined(out, std::move(fields));
 }
 

--- a/tests/data/output_feed/shapes.txt
+++ b/tests/data/output_feed/shapes.txt
@@ -1,0 +1,4 @@
+shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence,shape_dist_traveled
+id1,61.197843,-149.867731,0,0.0
+id1,61.199419,-149.867680,1,178.0
+id2,61.199972,-149.867731,2,416.0

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -651,5 +651,6 @@ TEST_CASE("Shapes create & save")
   Feed feed_for_testing("data/output_feed");
 
   REQUIRE_EQ(feed_for_testing.read_shapes(), ResultCode::OK);
+  CHECK_EQ(feed_for_testing.get_shapes().size(), 3);
 }
 TEST_SUITE_END();

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -638,4 +638,18 @@ TEST_CASE("Agencies create & save")
   REQUIRE_EQ(feed_for_testing.read_agencies(), ResultCode::OK);
   CHECK_EQ(feed_for_writing.get_agencies(), feed_for_testing.get_agencies());
 }
+
+TEST_CASE("Shapes create & save")
+{
+  Feed feed_for_writing;
+
+  feed_for_writing.add_shape(ShapePoint{"id1", 61.197843, -149.867731, 0, 0});
+  feed_for_writing.add_shape(ShapePoint{"id1", 61.199419, -149.867680, 1, 178});
+  feed_for_writing.add_shape(ShapePoint{"id2", 61.199972, -149.867731, 2, 416});
+
+  REQUIRE_EQ(feed_for_writing.write_shapes("data/output_feed"), ResultCode::OK);
+  Feed feed_for_testing("data/output_feed");
+
+  REQUIRE_EQ(feed_for_testing.read_shapes(), ResultCode::OK);
+}
 TEST_SUITE_END();


### PR DESCRIPTION
The header for shapes.txt is missing the shape_dist_traveled field, while the data actually writes it, resulting in a broken CSV.
